### PR TITLE
Add more clarity around free/paid submissions

### DIFF
--- a/content/submissions.mdx
+++ b/content/submissions.mdx
@@ -13,8 +13,6 @@ linkedTo:
   - catalogue
 ---
 
-<FreePaid paid={true} />
-
 At _Astrolabe_, we&rsquo;re looking for work about how we seek out, discover, and grasp onto connection. Into the woods.
 Across a line. Beneath the ocean. Along a seam. Into the branches of an alternate present or the crevasse of an
 alternate future. Across the rifts between one another.
@@ -30,11 +28,12 @@ Read [about *Astrolabe*](/about) for details on our mission and what we&rsquo;re
 
 ## The details
 
-*Astrolabe* is open for submissions year-round.
+*Astrolabe* is open for submissions year-round. We pay a **$50 honorarium** upon publication of one or more pieces from
+your submission.
 
-To help pay contributors and defer costs, we alternate between free and paid submission periods throughout the year. Our
-free windows begin the day we publish new work&mdash;on the spring equinox, summer solstice, autumnal equinox, and
-winter solstice&mdash;and stay open for a month. Here are the free windows for 2023:
+To help fund those payments, we alternate between free and paid submission periods throughout the year. Our free windows
+begin the day we publish new work&mdash;on the spring equinox, summer solstice, autumnal equinox, and winter
+solstice&mdash;and stay open for a month. Here are the free windows for 2023:
 
 - March 20th to April 20th
 - June 21st to July 21st
@@ -43,13 +42,12 @@ winter solstice&mdash;and stay open for a month. Here are the free windows for 2
 
 Some additional details:
 
-- We pay a **$50 honorarium** upon publication of one or more pieces from your submission.
 - We currently accept three types of work: **fiction, creative nonfiction, and photography &amp; art**. See below for
   genre-specific instructions. We&rsquo;re not a market for lineated poetry at the moment.
 - **We do accept simultaneous submissions**, but please let us know if your work was accepted for publication
   elsewhere—we&rsquo;ll be thrilled for your good news!
 - **No multiple submissions**—and if we don&rsquo;t accept your work, please wait until our next submission period
-  before trying again.
+  before trying again unless we specifically ask for more work.
 - We consider only **unpublished work**.
 
 We ask for first North American serial rights and non-exclusive print/anthology rights. All copyrights remain yours.
@@ -71,7 +69,7 @@ interactive—send a link to where we can view it online, or just ask!
 
 ## Time to submit!
 
-<Guidelines paid={true} />
+<Guidelines paid={false} dateFreeOpen="2023-03-20" dateFreeClose="2023-04-20" />
 
 Track your submissions on [Duotrope](https://duotrope.com/listing/35081/astrolabe), [Chill
 Subs](https://www.chillsubs.com/magazine/astrolabe), or [The Submission

--- a/content/submissions.mdx
+++ b/content/submissions.mdx
@@ -69,7 +69,7 @@ interactive—send a link to where we can view it online, or just ask!
 
 ## Time to submit!
 
-<Guidelines paid={false} dateFreeOpen="2023-03-20" dateFreeClose="2023-04-20" />
+<Guidelines paid={true} dateFreeOpen="2023-03-20" dateFreeClose="2023-04-20" />
 
 Track your submissions on [Duotrope](https://duotrope.com/listing/35081/astrolabe), [Chill
 Subs](https://www.chillsubs.com/magazine/astrolabe), or [The Submission

--- a/content/submissions.mdx
+++ b/content/submissions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Submissions
 summary: >-
-  Astrolabe is currently open during one of our fee-based submission windows.
+  Astrolabe is currently open for paid submissions, with our next free period opening on March 20th, 2023.
 declination: 1.4
 ascension: 6
 size: 20
@@ -31,9 +31,9 @@ Read [about *Astrolabe*](/about) for details on our mission and what we&rsquo;re
 *Astrolabe* is open for submissions year-round. We pay a **$50 honorarium** upon publication of one or more pieces from
 your submission.
 
-To help fund those payments, we alternate between free and paid submission periods throughout the year. Our free windows
+To help fund those payments, we alternate between free and paid submission periods throughout the year. Our free periods
 begin the day we publish new work&mdash;on the spring equinox, summer solstice, autumnal equinox, and winter
-solstice&mdash;and stay open for a month. Here are the free windows for 2023:
+solstice&mdash;and stay open for a month. Here are the free periods for 2023:
 
 - March 20th to April 20th
 - June 21st to July 21st

--- a/src/components/mdx/Submissions.js
+++ b/src/components/mdx/Submissions.js
@@ -70,10 +70,10 @@ const Guidelines = ({ paid, dateFreeOpen, dateFreeClose }) => {
                 />
               </form>
             </li>
+            <li>
+              We&rsquo;ll send a confirmation to let you know we received your submission and fee.
+            </li>
           </ol>
-          <p>
-            We&rsquo;ll send a confirmation to let you know we received your submission and fee.
-          </p>
           <p>
             We&rsquo;ll get back to you within <strong>one month</strong>&mdash;if we take longer,
             feel free to <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a>.

--- a/src/components/mdx/Submissions.js
+++ b/src/components/mdx/Submissions.js
@@ -1,5 +1,4 @@
 import moment from 'moment'
-import { PayPalScriptProvider, PayPalButtons } from '@paypal/react-paypal-js'
 
 const FreePaid = ({ paid, date }) => {
   const closeDate = Date.parse(date)
@@ -23,70 +22,95 @@ const FreePaid = ({ paid, date }) => {
   )
 }
 
-const Guidelines = ({ paid }) => {
+const Guidelines = ({ paid, dateFreeOpen, dateFreeClose }) => {
   return (
     <>
       {paid ? (
         <>
+          <p>
+            We are currently open to <strong>paid</strong> submissions. If you&rsquo;d prefer to not
+            pay a fee, our next free submission window is open between{' '}
+            {moment(dateFreeOpen).format('dddd, MMMM Do')} and{' '}
+            {moment(dateFreeClose).format('dddd, MMMM Do, YYYY')}.
+          </p>
           <p>To send a paid submission:</p>
           <ol>
             <li>
-              <span>
+              <span className="block mb-2">
                 Send your submission to{' '}
                 <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a> with the subject
                 line:
               </span>
-              <br />
-              <strong>Paid submission: Your Name, &ldquo;Title&rdquo;</strong>
-              <br />
+              <strong className="block mb-2">
+                Paid submission: Your Name, &ldquo;Title&rdquo;
+              </strong>
+              <span className="block mb-2">
+                Include a short cover letter, bio, and your work as an attachment(s).
+              </span>
               <span>
-                Include a short cover letter, bio, and your work as an attachment(s). No need to
-                send us your physical address or phone number.
+                We welcome pen names, author names, or pseudonyms. No need to include your legal
+                name, physical address, phone number, or other personal information with your
+                submission&mdash;the name you publish under and your email address is enough!
               </span>
             </li>
             <li>
-              Click the <strong>PayPal</strong> button below to pay the $5 fee.
+              <span className="block mb-2">
+                Click the <strong>PayPal</strong> button below to pay the $5 fee.
+              </span>
+              <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+                <input type="hidden" name="cmd" value="_s-xclick" />
+                <input type="hidden" name="hosted_button_id" value="7PZ9LDC4Q7FB4" />
+                <input
+                  className="px-4 py-3 border rounded hover:bg-gray-200 transition-all"
+                  type="image"
+                  src="https://www.paypalobjects.com/en_US/i/btn/btn_paynowCC_LG.gif"
+                  border="0"
+                  name="submit"
+                  alt="PayPal - The safer, easier way to pay online!"
+                />
+              </form>
             </li>
           </ol>
-          <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
-            <input type="hidden" name="cmd" value="_s-xclick" />
-            <input type="hidden" name="hosted_button_id" value="7PZ9LDC4Q7FB4" />
-            <input
-              type="image"
-              src="https://www.paypalobjects.com/en_US/i/btn/btn_paynowCC_LG.gif"
-              border="0"
-              name="submit"
-              alt="PayPal - The safer, easier way to pay online!"
-            />
-          </form>
+
           <p>
             We&rsquo;ll send a confirmation to let you know we received your submission and fee.
           </p>
           <p>
             We&rsquo;ll get back to you within <strong>one month</strong>&mdash;if we take longer,
-            feel free to <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a>. We're
-            strong believers that Wednesday is the least painful day of the week to send (or
-            receive) a rejection.
+            feel free to <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a>.
+            We&rsquo;re strong believers that Wednesday is the least painful day of the week to send
+            (or receive) a rejection.
           </p>
         </>
       ) : (
         <>
           <p>
-            Send submissions to <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a>.
+            We are currently <strong>open</strong> for free submissions until{' '}
+            {moment(dateFreeClose).format('dddd, MMMM Do, YYYY')}!
           </p>
-          <p>
-            Please format the subject line like so:{' '}
-            <strong>Submission: Your Name, &ldquo;Title&rdquo;</strong>
-          </p>
-          <p>
-            Include a short cover letter, bio, and your work as an attachment(s). No need to send us
-            your physical address or phone number.
-          </p>
+          <ol>
+            <li>
+              <span className="block mb-2">
+                Send your submission to{' '}
+                <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a> with the subject
+                line:
+              </span>
+              <strong className="block mb-2">Submission: Name, &ldquo;Title&rdquo;</strong>
+              <span className="block mb-2">
+                Include a short cover letter, bio, and your work as an attachment(s).
+              </span>
+              <span>
+                We welcome pen names, author names, or pseudonyms. No need to include your legal
+                name, physical address, phone number, or other personal information with your
+                submission&mdash;the name you publish under and your email address is enough!
+              </span>
+            </li>
+          </ol>
           <p>
             We&rsquo;ll get back to you within <strong>one month</strong>&mdash;if we take longer,
-            feel free to <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a>. We're
-            strong believers that Wednesday is the least painful day of the week to send (or
-            receive) a rejection.
+            feel free to <a href="mailto:editors@astrolabe.ooo">editors@astrolabe.ooo</a>.
+            We&rsquo;re strong believers that Wednesday is the least painful day of the week to send
+            (or receive) a rejection.
           </p>
         </>
       )}

--- a/src/components/mdx/Submissions.js
+++ b/src/components/mdx/Submissions.js
@@ -71,7 +71,6 @@ const Guidelines = ({ paid, dateFreeOpen, dateFreeClose }) => {
               </form>
             </li>
           </ol>
-
           <p>
             We&rsquo;ll send a confirmation to let you know we received your submission and fee.
           </p>

--- a/src/components/mdx/Submissions.js
+++ b/src/components/mdx/Submissions.js
@@ -29,7 +29,7 @@ const Guidelines = ({ paid, dateFreeOpen, dateFreeClose }) => {
         <>
           <p>
             We are currently open to <strong>paid</strong> submissions. If you&rsquo;d prefer to not
-            pay a fee, our next free submission window is open between{' '}
+            pay a fee, our next free submission period is open between{' '}
             {moment(dateFreeOpen).format('dddd, MMMM Do')} and{' '}
             {moment(dateFreeClose).format('dddd, MMMM Do, YYYY')}.
           </p>


### PR DESCRIPTION
I felt like the big banner at the top of the page, an artifact of before we launched and were truly closed to submissions, was more of a deterrent and didn't tell the whole story. I tweaked some of the verbiage and removed that banner altogether with the hope that people will read more of the guidelines and see, if they don't want to submit for a fee, when they'll be able to do so next.