### PR TITLE
Add prose customization styles

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -37,7 +37,7 @@ html {
 
 /* Prose */
 
-.star-content.prose > p:first-child:first-letter {
+.star-content.prose > p:not(.prose-no-dropcap):first-child:first-letter {
   float: left;
   @apply text-green text-8xl pt-2 pr-4;
   line-height: 1;

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -43,6 +43,10 @@ html {
   line-height: 1;
 }
 
+.prose-justify {
+  text-align-last: justify;
+}
+
 .prose a {
   @apply transform ease-in-out duration-300;
 }


### PR DESCRIPTION
A `.prose-no-dropcap` class to be added in `.mdx` files when the work doesn't want a dropcap.

A `.prose-justify` class for when we want to justify single lines of text—relevant when line endings are significant and need to be broken with a `<br />`.