### PR TITLE
Fix bug around absolute paths to .mdx files

### DIFF
--- a/app/[slug]/page.js
+++ b/app/[slug]/page.js
@@ -13,6 +13,11 @@ async function getStars() {
   return posts
 }
 
+export async function generateStaticParams() {
+  const posts = await getFrontMatter(STAR_CONTENT_PATH)
+  return posts
+}
+
 export async function generateMetadata({ params: { slug } }) {
   const { frontMatter } = await getStar(slug)
 
@@ -62,7 +67,7 @@ export async function generateMetadata({ params: { slug } }) {
 }
 
 export default async function Star({ params: { slug } }) {
-  const posts = await getStars()
+  const posts = await generateStaticParams()
   const star = await getStar(slug)
 
   return (

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'fs'
-import glob from 'fast-glob'
+import fg from 'fast-glob'
 import matter from 'gray-matter'
 import path from 'path'
 import { bundleMDX } from 'mdx-bundler'
@@ -23,11 +23,10 @@ export async function getSingleContent(slug) {
   // does, return the MDX content as normal. If it doesn't throw a `notFound()`
   // to then display a 404 without rendering the rest of the page.
   try {
-    // Find the .mdx file based on its slug, no matter the folder structure.
-    const filepath = path.join(root, glob.globSync(`${ROOT_CONTENT}/**/${slug}.mdx`)[0])
+    const filepath = await fg.glob(`${root}/**/${slug}.mdx`, { baseNameMatch: true })
 
     const { frontmatter, code } = await bundleMDX({
-      file: filepath,
+      file: filepath.toString(),
       cwd: path.join(process.cwd(), 'src/components'),
       mdxOptions(options) {
         // this is the recommended way to add custom remark/rehype plugins:
@@ -68,7 +67,7 @@ export async function getSingleContent(slug) {
 }
 
 export async function getFrontMatter(...source) {
-  const files = await glob.sync(source)
+  const files = await fg.glob(source)
   if (!files.length) return []
 
   const allFrontMatter = await Promise.all(

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'fs'
-import { globbySync } from 'globby'
+import glob from 'fast-glob'
 import matter from 'gray-matter'
 import path from 'path'
 import { bundleMDX } from 'mdx-bundler'
@@ -19,14 +19,13 @@ export function dateSortDesc(a, b) {
 export async function getSingleContent(slug) {
   let authorBioCode
 
-  // Find the file regardless of its path.
-  const filepath = path.join(root, globbySync(`${ROOT_CONTENT}/**/${slug}.mdx`)[0])
-
   // This is messy, but it works. Catch whether the `filepath` exists. If it
   // does, return the MDX content as normal. If it doesn't throw a `notFound()`
   // to then display a 404 without rendering the rest of the page.
   try {
-    await fsp.access(filepath)
+    // Find the .mdx file based on its slug, no matter the folder structure.
+    const filepath = path.join(root, glob.globSync(`${ROOT_CONTENT}/**/${slug}.mdx`)[0])
+
     const { frontmatter, code } = await bundleMDX({
       file: filepath,
       cwd: path.join(process.cwd(), 'src/components'),
@@ -69,7 +68,7 @@ export async function getSingleContent(slug) {
 }
 
 export async function getFrontMatter(...source) {
-  const files = await globbySync(source)
+  const files = await glob.sync(source)
   if (!files.length) return []
 
   const allFrontMatter = await Promise.all(

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -8,6 +8,8 @@ import rehypeSlug from 'rehype-slug'
 import { notFound } from 'next/navigation'
 import { ROOT_CONTENT } from '@config/constants'
 
+const root = process.cwd()
+
 export function dateSortDesc(a, b) {
   if (a > b) return -1
   if (a < b) return 1
@@ -18,7 +20,7 @@ export async function getSingleContent(slug) {
   let authorBioCode
 
   // Find the file regardless of its path.
-  const filepath = path.resolve(globbySync(`${ROOT_CONTENT}/**/${slug}.mdx`)[0])
+  const filepath = path.join(root, globbySync(`${ROOT_CONTENT}/**/${slug}.mdx`)[0])
 
   // This is messy, but it works. Catch whether the `filepath` exists. If it
   // does, return the MDX content as normal. If it doesn't throw a `notFound()`

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -19,6 +19,8 @@ export function dateSortDesc(a, b) {
 export async function getSingleContent(slug) {
   let authorBioCode
 
+  // console.log(slug + ': ' + (await fg.glob(`${root}/**/${slug}.mdx`, { baseNameMatch: true })))
+
   // This is messy, but it works. Catch whether the `filepath` exists. If it
   // does, return the MDX content as normal. If it doesn't throw a `notFound()`
   // to then display a 404 without rendering the rest of the page.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^10.4.0",
     "d3": "^5.5.0",
     "esbuild": "^0.15.16",
+    "fast-glob": "^3.3.2",
     "image-size": "1.0.0",
     "lodash": "^4.17.21",
     "mdx-bundler": "^9.0.1",


### PR DESCRIPTION
Fix a bug introduced in #109 that throws the following error when trying to navigate to an example or star once the project is deployed to Vercel:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
```